### PR TITLE
Demonstrate workaround for classloader issue

### DIFF
--- a/mock-codegen-plugin/src/main/java/com/kylemoore/gradle/tool/MockCodegenTask.java
+++ b/mock-codegen-plugin/src/main/java/com/kylemoore/gradle/tool/MockCodegenTask.java
@@ -11,6 +11,9 @@ import org.gradle.workers.WorkerExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
 
 public class MockCodegenTask extends DefaultTask {
 
@@ -74,16 +77,32 @@ public class MockCodegenTask extends DefaultTask {
 
   @TaskAction
   public void generate() {
-    workerExecutor.submit(MockCodegenRunner.class, config -> {
-      config.setIsolationMode(IsolationMode.PROCESS);
-      config.setClasspath(getToolClasspath());
-      config.forkOptions(javaForkOptions -> {
-        javaForkOptions.setDebug(isDebugEnabled());
-      });
-      config.setDisplayName("Mock Codegen Daemon");
-      config.params(getCompileClasspath().getAsPath(), //compileClasspath
-              getClassesToAnalyze().getSingleFile().getAbsolutePath(), //analysisDir
-              getOutputFile().getAbsolutePath()); //outputFile
-    });
+      ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+      try {
+          Thread.currentThread().setContextClassLoader(getMinimumClassLoader());
+          workerExecutor.submit(MockCodegenRunner.class, config -> {
+              config.setIsolationMode(IsolationMode.PROCESS);
+              config.setClasspath(getToolClasspath());
+              config.forkOptions(javaForkOptions -> {
+                  javaForkOptions.setDebug(isDebugEnabled());
+              });
+              config.setDisplayName("Mock Codegen Daemon");
+              config.params(getCompileClasspath().getAsPath(), //compileClasspath
+                  getClassesToAnalyze().getSingleFile().getAbsolutePath(), //analysisDir
+                  getOutputFile().getAbsolutePath()); //outputFile
+          });
+      } finally {
+          Thread.currentThread().setContextClassLoader(originalClassLoader);
+      }
+  }
+
+  private ClassLoader getMinimumClassLoader() {
+      URLClassLoader contextClassloader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+      URL[] urls = Arrays.stream(contextClassloader.getURLs()).filter(url -> isModule(url, "mock-codegen-plugin")).toArray(URL[]::new);
+      return new URLClassLoader(urls, contextClassloader.getParent());
+  }
+
+  private boolean isModule(URL url, String moduleName) {
+      return url.getFile() != null && new File(url.getFile()).getName().startsWith(moduleName);
   }
 }

--- a/mock-codegen-tool/src/main/java/com/kylemoore/tool/ChildFirstClassLoader.java
+++ b/mock-codegen-tool/src/main/java/com/kylemoore/tool/ChildFirstClassLoader.java
@@ -1,0 +1,28 @@
+package com.kylemoore.tool;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class ChildFirstClassLoader extends URLClassLoader {
+
+    public ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> loadedClass = findLoadedClass(name);
+        if (loadedClass == null) {
+            try {
+                loadedClass = findClass(name);
+            } catch (ClassNotFoundException e) {
+                loadedClass = super.loadClass(name, resolve);
+            }
+        }
+
+        if (resolve) {
+            resolveClass(loadedClass);
+        }
+        return loadedClass;
+    }
+}

--- a/mock-codegen-tool/src/main/java/com/kylemoore/tool/MockCodegenTool.java
+++ b/mock-codegen-tool/src/main/java/com/kylemoore/tool/MockCodegenTool.java
@@ -39,7 +39,7 @@ public class MockCodegenTool {
     // 5.6.4 + legacy API: getURLs() -> [mock-codegen-tool.jar, mock-codegen-plugin.jar, guava-r06.jar]
     ClassLoader workerDaemonClassLoader = Thread.currentThread().getContextClassLoader();
 
-    URLClassLoader singleUseClassLoader = new URLClassLoader(urls.toArray(new URL[0]), workerDaemonClassLoader);
+    URLClassLoader singleUseClassLoader = new ChildFirstClassLoader(urls.toArray(new URL[0]), workerDaemonClassLoader);
 
     executeWithChildClassLoader(singleUseClassLoader, () -> {
       Class<?> lists = Class.forName("com.google.common.collect.Lists", false, Thread.currentThread().getContextClassLoader());


### PR DESCRIPTION
This demonstrates a possible workaround for the issue described.  Basically, with the legacy API, we derive the classloader for the work action from the context classloader (which is essentially the buildscript classloader).   In order to avoid dragging other stuff from that classloader along, we construct a new classloader that contains only the minimum set of jars necessary to run our unit of work and set that as the context classloader while we call submit().